### PR TITLE
Corrected setup.py to correctly locate python scripts and added MANIF…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Kevin Wu',
     author_email='me@kevinformatics.com',
     url='https://github.com/kevinwuhoo/randomcolor-py',
-    packages=find_packages(),
+    packages=["."],
     include_package_data=True,
     install_requires=[],
 )


### PR DESCRIPTION
Corrected setup.py to correctly locate python script and added MANIFEST.in to package up README.md which is required for installation from sdist archive.

I couldn't get it to install with `pip install randomcolor` so I came here to get the source. After running `python setup.py install`, there was nothing to import either, so I checked the setup script, and sure enough `setuptools` wasn't able to find a package. 

I replaced the call to `find_packages` which returned an empty list with a list of the python scripts to package. `find_packages` is only really appropriate when there's a whole directory to pack up. Since the setup script also depends upon having the README file on hand, and the README is not one of the standard formats, I added `MANIFEST.in` to include it.
