### PR TITLE
Remove broken shebang

### DIFF
--- a/randomcolor/__init__.py
+++ b/randomcolor/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/env/bin python
-
 import os
 import colorsys
 import random


### PR DESCRIPTION
The shebang was broken (`/usr/env/bin` instead of `/usr/bin/env`) and is of no use, since this module contains no executable code.